### PR TITLE
Update requirements to fix setup, remove regnet

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ leidenalg>=0.8.3
 einops>=0.6
 colorcet>=3.0.1
 transformers
-regnet

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,13 @@ numpy>=1.22.1
 pandas>=1.4.0
 scipy>=1.7.3
 torch>=1.10.0
-pytorch_lightning>=1.9
+# TODO: remove max version once add_argparse_args is removed
+pytorch-lightning<2.0
+lightning<2.0
 scanpy>=1.8.2
 muon>=0.1.2
 leidenalg>=0.8.3
+einops>=0.6
+colorcet>=3.0.1
 transformers
+regnet

--- a/scclip/vit.py
+++ b/scclip/vit.py
@@ -9,9 +9,6 @@ from transformers.utils import ModelOutput
 from dataclasses import dataclass
 from einops import rearrange
 
-from regnet.utils import pearsonr
-
-
 @dataclass
 class MaskedLMOutput(ModelOutput):
     loss: Optional[torch.FloatTensor] = None
@@ -433,7 +430,8 @@ class ViTMLM(ViTPreTrainedModel):
 
         log_dict = {
             f'loss/{mode}': output.loss,
-            f'corr/{mode}': pearsonr(batch, output.logits).nanmean()
+            # TODO: add back in pearson R calculation w/o regnet package
+            #f'corr/{mode}': pearsonr(batch, output.logits).nanmean()
         }
 
         if mode == 'predict':


### PR DESCRIPTION
Adds previously undocumented dependencies to `requirements.txt`, removes referral to internal `regnet` package, and sets a max version on `lightning` and `pytorch_lightning` due to the removal of the `add_argparse_args`  function in the 2.0 release ([ref](https://github.com/Lightning-AI/lightning/pull/16708))